### PR TITLE
Fix for hoppers.

### DIFF
--- a/src/CortexPE/tile/Hopper.php
+++ b/src/CortexPE/tile/Hopper.php
@@ -208,10 +208,10 @@ class Hopper extends Spawnable implements InventoryHolder, Container, Nameable {
 							$left = $inv->getLeftSide();
 							$right = $inv->getRightSide();
 
-							if($right->canAddItem($targetItem)){
-								$inv = $right;
-							}else{
+							if($left->canAddItem($targetItem)){
 								$inv = $left;
+							}else{
+								$inv = $right;
 							}
 						}
 


### PR DESCRIPTION
This PR Fixes hoppers putting items in the bottom half of double chests and puts them in order of available spaces instead.